### PR TITLE
Support multiple product orders

### DIFF
--- a/example-terraform.tfvars
+++ b/example-terraform.tfvars
@@ -6,7 +6,7 @@ subnet_b_cidr_block = "10.10.16.0/20"
 subnet_c_cidr_block = "10.10.32.0/20"
 order_size_in_usd   = "20"
 product_id          = "BTC-USD"
-product_order_pairs = [
-  {product_name = "bitcoin", product_id = "BTC-USD", order_size = 100},
-	{product_name = "ethereum", product_id = "ETH-USD", order_size = 100},
-]
+product_order_pairs = {
+	BTC-USD = 100
+	ETH-USD = 100
+}

--- a/example-terraform.tfvars
+++ b/example-terraform.tfvars
@@ -5,3 +5,8 @@ subnet_a_cidr_block = "10.10.0.0/20"
 subnet_b_cidr_block = "10.10.16.0/20"
 subnet_c_cidr_block = "10.10.32.0/20"
 order_size_in_usd   = "20"
+product_id          = "BTC-USD"
+product_order_pairs = [
+  {product_name = "bitcoin", product_id = "BTC-USD", order_size = 100},
+	{product_name = "ethereum", product_id = "ETH-USD", order_size = 100},
+]

--- a/main.tf
+++ b/main.tf
@@ -278,18 +278,12 @@ resource "aws_cloudwatch_event_target" "lambda_deposit_event_target" {
   arn       = aws_lambda_function.coinbase_lambda_deposit.arn
 }
 
-resource "aws_cloudwatch_event_target" "lambda_order_event_target_bitcoin" {
+resource "aws_cloudwatch_event_target" "lambda_order_event_target" {
+  for_each = var.product_order_pairs
   rule      = aws_cloudwatch_event_rule.lambda_order_event_rule.name
-  target_id = "SendToOrderLambdaBTC"
+  target_id = "SendToOrderLambda${each.key}"
   arn       = aws_lambda_function.coinbase_lambda_order.arn
-  input     = "{\"product_id\":\"${var.product_id}\", \"order_size\":${var.order_size_in_usd}}"
-}
-
-resource "aws_cloudwatch_event_target" "lambda_order_event_target_ethereum" {
-  rule      = aws_cloudwatch_event_rule.lambda_order_event_rule.name
-  target_id = "SendToOrderLambdaETH"
-  arn       = aws_lambda_function.coinbase_lambda_order.arn
-  input     = "{\"product_id\":\"ETH-USD\", \"order_size\":${var.order_size_in_usd}}"
+  input     = "{\"product_id\":\"${each.key}\", \"order_size\":${each.value}}"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_deposit_lambda" {

--- a/main.tf
+++ b/main.tf
@@ -258,12 +258,6 @@ resource "aws_lambda_function" "coinbase_lambda_order" {
     subnet_ids         = [aws_subnet.coinbase_subnet_b.id, aws_subnet.coinbase_subnet_c.id]
     security_group_ids = [aws_security_group.lambda_sg.id]
   }
-
-  environment {
-    variables = {
-      ORDER_SIZE_IN_USD = var.order_size_in_usd
-    }
-  }
 }
 
 resource "aws_cloudwatch_event_rule" "lambda_deposit_event_rule" {
@@ -284,10 +278,18 @@ resource "aws_cloudwatch_event_target" "lambda_deposit_event_target" {
   arn       = aws_lambda_function.coinbase_lambda_deposit.arn
 }
 
-resource "aws_cloudwatch_event_target" "lambda_order_event_target" {
+resource "aws_cloudwatch_event_target" "lambda_order_event_target_bitcoin" {
   rule      = aws_cloudwatch_event_rule.lambda_order_event_rule.name
-  target_id = "SendToOrderLambda"
+  target_id = "SendToOrderLambdaBTC"
   arn       = aws_lambda_function.coinbase_lambda_order.arn
+  input     = "{\"product_id\":\"${var.product_id}\", \"order_size\":${var.order_size_in_usd}}"
+}
+
+resource "aws_cloudwatch_event_target" "lambda_order_event_target_ethereum" {
+  rule      = aws_cloudwatch_event_rule.lambda_order_event_rule.name
+  target_id = "SendToOrderLambdaETH"
+  arn       = aws_lambda_function.coinbase_lambda_order.arn
+  input     = "{\"product_id\":\"ETH-USD\", \"order_size\":${var.order_size_in_usd}}"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_deposit_lambda" {

--- a/python-scripts/order-crypto.py
+++ b/python-scripts/order-crypto.py
@@ -2,9 +2,7 @@ import json, hmac, hashlib, time, requests, base64, os, boto3
 from requests.auth import AuthBase
 
 API_PERMISSION = "trade"
-ORDER_SIZE_IN_USD = os.environ['ORDER_SIZE_IN_USD']
 ORDER_SIDE = "buy"
-PRODUCT_ID = "BTC-USD"
 
 class CoinbaseExchangeAuth(AuthBase):
 	def __init__(self, api_key, secret_key, passphrase):
@@ -43,12 +41,13 @@ def get_api_keys():
 	return api_keys
 
 def lambda_handler(event, context):
-	order_size_float = float(ORDER_SIZE_IN_USD)
+	order_size_float = float(event["order_size"])
+	product_id = event["product_id"]
 	api_url = 'https://api.pro.coinbase.com/'
 	keys = get_api_keys()
 	auth = CoinbaseExchangeAuth(keys['api_key'], keys['api_secret'], keys['api_pass'])
 
-	product_response = requests.get(api_url + 'products/{}/ticker'.format(PRODUCT_ID))
+	product_response = requests.get(api_url + 'products/{}/ticker'.format(product_id))
 	ask_price = product_response.json()['ask']
 
 	maximum_fee = order_size_float * .005
@@ -58,7 +57,7 @@ def lambda_handler(event, context):
 		'size': order_size,
 		'price': ask_price,
 		'side': ORDER_SIDE,
-		'product_id': PRODUCT_ID
+		'product_id': product_id
 	}
 	order_data = json.dumps(order_data)
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,24 @@ variable "order_size_in_usd" {
 	type = string
 	description = "The amount in USD of the selected currency to trade"
 }
+
+variable "product_id" {
+	type        = string
+	description = "The Id of the Coinbase crypto product to order"
+	default     = "BTC-USD"
+}
+
+variable "product_order_pairs" {
+  type        = list(object({
+	  product_name = string
+		product_id   = string
+		order_size   = number
+	}))
+	default = [
+	  {
+		  product_name = "bitcoin"
+			product_id   = "BTC-USD"
+			order_size   = 100
+		}
+	]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,16 +40,9 @@ variable "product_id" {
 }
 
 variable "product_order_pairs" {
-  type        = list(object({
-	  product_name = string
-		product_id   = string
-		order_size   = number
-	}))
-	default = [
-	  {
-		  product_name = "bitcoin"
-			product_id   = "BTC-USD"
-			order_size   = 100
-		}
-	]
+  type        = map(string)
+	description = "An object containing the Coinbase product_ids and their order sizes to execute"
+	default     = {
+	  BTC-USD   = 100
+	}
 }


### PR DESCRIPTION
This merge request updates the variable, `product_order_pairs`, and the associated Terraform resources in main.tf to create multiple CloudWatch Event Targets for each crypto product to order. This makes it easier to add and remove recurring orders for crypto products.