### PR TITLE
Initial cloudwatch alarms

### DIFF
--- a/example-terraform.tfvars
+++ b/example-terraform.tfvars
@@ -11,6 +11,7 @@ monthly_cron_expression  = "cron(0 0 1 * ? *)"
 weekly_product_orders    = {
 	BTC-USD  = 100
 }
-monthly_product_orders  = {
+monthly_product_orders   = {
 	ETH-USD  = 100
 }
+sms_number_for_errors    = "+12345678910"

--- a/main.tf
+++ b/main.tf
@@ -324,6 +324,7 @@ resource "aws_sns_topic" "order_lambda_errors" {
 }
 
 resource "aws_sns_topic_subscription" "lambda_order_errors_sms_target" {
+  count = var.sms_number_for_errors != "" ? 1 : 0
   topic_arn = aws_sns_topic.order_lambda_errors.arn
   protocol  = "sms"
   endpoint  = var.sms_number_for_errors

--- a/python-scripts/deposit-funds.py
+++ b/python-scripts/deposit-funds.py
@@ -67,10 +67,8 @@ def lambda_handler(event, context):
 			'body': http_error.response.json()
 		}
 	except Exception as error:
-		return {
-			'statusCode': 400,
-			'body': json.dumps(str(error))
-		}
+		print("An ERROR occurred: {}".format(str(error)))
+		raise
 	else:
 		return {
 			'statusCode': deposit_response.status_code,

--- a/python-scripts/order-crypto.py
+++ b/python-scripts/order-crypto.py
@@ -73,10 +73,8 @@ def lambda_handler(event, context):
 			'body': http_error.response.json()
 		}
 	except Exception as error:
-		return {
-			'statusCode': 400,
-			'body': json.dumps(str(error))
-		}
+		print("An ERROR occurred: {}".format(str(error)))
+		raise
 	else:
 		return {
 			'statusCode': order_response.status_code,

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,8 @@ variable "monthly_product_orders" {
 	  ETH-USD   = 100
 	}
 }
+
+variable "sms_number_for_errors" {
+	type        = string
+	description = "The SMS number in which to send alerts whenever the Order Lambda function has a Non-HTTP Error"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,4 +67,5 @@ variable "monthly_product_orders" {
 variable "sms_number_for_errors" {
 	type        = string
 	description = "The SMS number in which to send alerts whenever the Order Lambda function has a Non-HTTP Error"
+	default     = ""
 }


### PR DESCRIPTION
This pull request adds CloudWatch alarms for the two lambda functions, and the corresponding SNS topics and SMS subscribers. These alerts are only for errors with the lambda functions, not HTTP errors associated with any Coinbase Pro API requests.